### PR TITLE
Update for 2.0.8 Add Viewing Key capability 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BitcoinZ Wallet 2.0.7-u3
+# BitcoinZ Wallet 2.0.8-rc1
 
 [Download here](https://github.com/btcz/bitcoinz-wallet/releases)
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The details of how to build it are described below (easy to follow).
 
    3.1. If you have built BitcoinZ from source code:
 
-     Assuming you have already built from source code [BitcoinZ](https://github.com/btcz/bitcoinz) in directory `/home/user/bitcoinz/src` (for example - this is the typical build dir. for bitcoinz v2.0.7) which contains the command line tools `bitcoinz-cli` and `bitcoinzd` you need to take the created file `./build/jars/BitcoinZWallet.jar` and copy it to directory `/home/user/bitcoinz/src` (the same dir. that contains `bitcoinz-cli` and `bitcoinzd`). Example copy command:
+     Assuming you have already built from source code [BitcoinZ](https://github.com/btcz/bitcoinz) in directory `/home/user/bitcoinz/src` (for example - this is the typical build dir. for bitcoinz v2.0.8) which contains the command line tools `bitcoinz-cli` and `bitcoinzd` you need to take the created file `./build/jars/BitcoinZWallet.jar` and copy it to directory `/home/user/bitcoinz/src` (the same dir. that contains `bitcoinz-cli` and `bitcoinzd`). Example copy command:
       ```
       cp ./build/jars/BitcoinZWallet.jar /home/user/zen/src    
       ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BitcoinZ Wallet 2.0.8-rc1
+# BitcoinZ Wallet 2.0.8
 
 [Download here](https://github.com/btcz/bitcoinz-wallet/releases)
 

--- a/src/build/build.xml
+++ b/src/build/build.xml
@@ -100,7 +100,7 @@
 
     <target name="ubuntuPackage" depends="jar,copyothers">
     	<mkdir dir="${ubuntu.package.dir}"/>
-	    <deb destfile="${ubuntu.package.dir}/bitcoinz-wallet_2.0.8-rc1.deb"
+	    <deb destfile="${ubuntu.package.dir}/bitcoinz-wallet_2.0.8.deb"
 	    	 control="${src.dir}/resources/ubuntu-package"
 	    	 verbose="true">
 

--- a/src/build/build.xml
+++ b/src/build/build.xml
@@ -100,7 +100,7 @@
 
     <target name="ubuntuPackage" depends="jar,copyothers">
     	<mkdir dir="${ubuntu.package.dir}"/>
-	    <deb destfile="${ubuntu.package.dir}/bitcoinz-wallet_2.0.7-u3.deb"
+	    <deb destfile="${ubuntu.package.dir}/bitcoinz-wallet_2.0.8-rc1.deb"
 	    	 control="${src.dir}/resources/ubuntu-package"
 	    	 verbose="true">
 

--- a/src/java/com/bitcoinz/btczui/AboutDialog.java
+++ b/src/java/com/bitcoinz/btczui/AboutDialog.java
@@ -86,7 +86,7 @@ public class AboutDialog extends JDialog{
 			" |____/ | |   | |/ /   / / \\ \\| |  | |\\ | |  / / \\ \\ /\\ / / _` | | |/ _ \\ __| | | || |  \n" +
 			" | ___ \\| |_  | |\\ \\__ \\ \\_/ /| |_ | | \\  | / /_  \\ V  V / (_| | | |  __/ |_| |_| || |  \n" +
 			" |_____/____| |_| \\____|\\___/_____||_|  \\_|/____|  \\_/\\_/ \\__,_|_|_|\\___|\\__|\\___/|___| \n" +
-			"  Version 2.0.7-u3 \n \n"  +
+			"  Version 2.0.8-rc1 \n \n"  +
 
 		    " Copyright (c) 2017-2022 BitcoinZ team \n" +
 		    " Copyright (c) 2016-2018 Ivan Vaklinov &lt;ivan@vaklinov.com&gt; \n" +
@@ -128,7 +128,7 @@ public class AboutDialog extends JDialog{
 		aboutNORTH_CENTER.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		aboutNORTH_CENTER.setText(
 				"<html><b><span style='font-weight:bold;font-size:2.3em'>" +
-				"BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.7-u3</html>");
+				"BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.8-rc1</html>");
 
 		// About description
 		JLabel aboutCENTER = new JLabel();
@@ -180,6 +180,9 @@ public class AboutDialog extends JDialog{
 		updateLogText.setText(
 				"<html>" +
 					"<div style='display: table; padding: 10px; height: 400px; max-width: 600px; overflow: hidden;'>  " +
+
+					"<b><u>v2.0.8-rc1 (JUL-2022)</u></b><br>"+
+					"- Added Viewing key import and usage. <br><br>"+
 
 						"<b><u>v2.0.7-u3 (MAY-2022)</u></b><br>"+
 						"- Added option to disable the (z) messaging. <br>"+

--- a/src/java/com/bitcoinz/btczui/AboutDialog.java
+++ b/src/java/com/bitcoinz/btczui/AboutDialog.java
@@ -86,7 +86,7 @@ public class AboutDialog extends JDialog{
 			" |____/ | |   | |/ /   / / \\ \\| |  | |\\ | |  / / \\ \\ /\\ / / _` | | |/ _ \\ __| | | || |  \n" +
 			" | ___ \\| |_  | |\\ \\__ \\ \\_/ /| |_ | | \\  | / /_  \\ V  V / (_| | | |  __/ |_| |_| || |  \n" +
 			" |_____/____| |_| \\____|\\___/_____||_|  \\_|/____|  \\_/\\_/ \\__,_|_|_|\\___|\\__|\\___/|___| \n" +
-			"  Version 2.0.8-rc1 \n \n"  +
+			"  Version 2.0.8 \n \n"  +
 
 		    " Copyright (c) 2017-2022 BitcoinZ team \n" +
 		    " Copyright (c) 2016-2018 Ivan Vaklinov &lt;ivan@vaklinov.com&gt; \n" +
@@ -128,7 +128,7 @@ public class AboutDialog extends JDialog{
 		aboutNORTH_CENTER.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		aboutNORTH_CENTER.setText(
 				"<html><b><span style='font-weight:bold;font-size:2.3em'>" +
-				"BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.8-rc1</html>");
+				"BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.8</html>");
 
 		// About description
 		JLabel aboutCENTER = new JLabel();
@@ -181,7 +181,7 @@ public class AboutDialog extends JDialog{
 				"<html>" +
 					"<div style='display: table; padding: 10px; height: 400px; max-width: 600px; overflow: hidden;'>  " +
 
-					"<b><u>v2.0.8-rc1 (JUL-2022)</u></b><br>"+
+					"<b><u>v2.0.8 (SEP-2022)</u></b><br>"+
 					"- Added Viewing key import and usage. <br><br>"+
 
 						"<b><u>v2.0.7-u3 (MAY-2022)</u></b><br>"+

--- a/src/java/com/bitcoinz/btczui/AddressTable.java
+++ b/src/java/com/bitcoinz/btczui/AddressTable.java
@@ -67,7 +67,7 @@ extends DataTable {
 							if ((lastRow >= 0) && (lastColumn >= 0)){
 								try{
 
-									String address = AddressTable.this.getModel().getValueAt(lastRow, 2).toString();
+									String address = AddressTable.this.getModel().getValueAt(lastRow, 3).toString();
 									boolean isZAddress = Util.isZAddress(address);
 
 									// Check for encrypted wallet
@@ -121,7 +121,7 @@ extends DataTable {
 							if ((lastRow >= 0) && (lastColumn >= 0)){
 								try{
 
-									String address = AddressTable.this.getModel().getValueAt(lastRow, 2).toString();
+									String address = AddressTable.this.getModel().getValueAt(lastRow, 3).toString();
 									boolean isZAddress = Util.isZAddress(address);
 
 									// Check for encrypted wallet
@@ -176,7 +176,7 @@ extends DataTable {
 							if ((lastRow >= 0) && (lastColumn >= 0)){
 								try{
 
-									String address = AddressTable.this.getModel().getValueAt(lastRow, 2).toString();
+									String address = AddressTable.this.getModel().getValueAt(lastRow, 3).toString();
 									boolean isZAddress = Util.isZAddress(address);
 
 									// Check for encrypted wallet
@@ -253,7 +253,7 @@ extends DataTable {
 				{
 					try
 					{
-						String address = AddressTable.this.getModel().getValueAt(lastRow, 2).toString();
+						String address = AddressTable.this.getModel().getValueAt(lastRow, 3).toString();
 						boolean isZAddress = Util.isZAddress(address);
 
 						// Check for encrypted wallet

--- a/src/java/com/bitcoinz/btczui/BTCZClientCaller.java
+++ b/src/java/com/bitcoinz/btczui/BTCZClientCaller.java
@@ -258,25 +258,48 @@ public class BTCZClientCaller
 	    return strTransactions;
 	}
 
-
-	public synchronized String[] getWalletZAddresses()
+	// Changed to list return to add viewing key
+	public synchronized List<List> getWalletZAddresses()
 		throws WalletCallException, IOException, InterruptedException
 	{
+
+		// Modified for the Viewing key for YODA 2.0.8
+		// TODO : return the VK advice from the cli ?
 		JsonArray jsonAddresses = executeCommandAndGetJsonArray("z_listaddresses", null);
-		String strAddresses[] = new String[jsonAddresses.size()];
+		JsonArray jsonAddressesVK = executeCommandAndGetJsonArray("z_listaddresses", "true");
+		List<String> strAddresses = new ArrayList<String>(); // [jsonAddresses.size()+jsonAddressesVK.size()];
+		List<Boolean> isVKonly = new ArrayList<Boolean>();  //[jsonAddresses.size()+jsonAddressesVK.size()];
+
 		for (int i = 0; i < jsonAddresses.size(); i++)
 		{
-		    strAddresses[i] = jsonAddresses.get(i).asString();
+		    strAddresses.add(jsonAddresses.get(i).asString());
+				isVKonly.add(false);
 		}
 
-	    return strAddresses;
+		// The order of the keys can not be defined (viwing or spending)
+		// Also a secound loop needs to be done to diferiencate it... :-|
+		// TODO: Find a better way or maybe return it from cli directly.
+		for (int i = 0; i < jsonAddressesVK.size(); i++)
+		{
+			if(strAddresses.contains(jsonAddressesVK.get(i).asString()) == false)
+			{
+				strAddresses.add(jsonAddressesVK.get(i).asString());
+				isVKonly.add(true);
+			}
+
+		}
+
+			List<List> retVal = new ArrayList<List>();
+			retVal.add(strAddresses);
+			retVal.add(isVKonly);
+	    return retVal;
 	}
 
 
 	public synchronized String[][] getWalletZReceivedTransactions()
 		throws WalletCallException, IOException, InterruptedException
 	{
-		String[] zAddresses = this.getWalletZAddresses();
+		List<String> zAddresses = this.getWalletZAddresses().get(0);
 
 		List<String[]> zReceivedTransactions = new ArrayList<String[]>();
 

--- a/src/java/com/bitcoinz/btczui/BTCZClientCaller.java
+++ b/src/java/com/bitcoinz/btczui/BTCZClientCaller.java
@@ -1173,6 +1173,20 @@ public class BTCZClientCaller
 			}
 			else throw new WalletCallException("Unexpected response from wallet: " + strResult); // Obviously an error
 		}
+		// The Viewing Key bigin with z : zxviews1qvnx7...
+		else if (first_letter.equals("Z") || first_letter.equals("z"))
+		{
+			String strResult = this.executeCommandAndGetSingleStringResponse(
+				"-rpcclienttimeout=5000", "z_importviewingkey", wrapStringParameter(key));
+
+				// TODO: Give the possibility to rescan. By default the VK do not rescan.
+
+			if (!strResult.trim().toLowerCase(Locale.ROOT).contains("error"))
+			{
+				return strResult == null ? "" : strResult.trim();
+			}
+			else throw new WalletCallException("Unexpected response from wallet: " + strResult); // Obviously an error
+		}
 		else
 		{
 			throw new WalletCallException(isTestnet == true ? "TestNet private key should start with a '9' or 'c'" : "Single private key should start with L, K, or 5");

--- a/src/java/com/bitcoinz/btczui/BTCZClientCaller.java
+++ b/src/java/com/bitcoinz/btczui/BTCZClientCaller.java
@@ -240,7 +240,7 @@ public class BTCZClientCaller
 	    String strTransactions[][] = new String[jsonTransactions.size()][];
 	    for (int i = 0; i < jsonTransactions.size(); i++)
 	    {
-	    	strTransactions[i] = new String[7];
+	    	strTransactions[i] = new String[8];
 	    	JsonObject trans = jsonTransactions.get(i).asObject();
 
 	    	// Needs to be the same as in getWalletZReceivedTransactions()
@@ -248,10 +248,11 @@ public class BTCZClientCaller
 	    	strTransactions[i][0] = "\u2606T (Public)";
 	    	strTransactions[i][1] = trans.getString("category", "ERROR!");
 	    	strTransactions[i][2] = trans.get("confirmations").toString();
-	    	strTransactions[i][3] = trans.get("amount").toString();
-	    	strTransactions[i][4] = trans.get("time").toString();
-	    	strTransactions[i][5] = trans.getString("address", notListed + " (Z Address not listed by wallet!)");
-	    	strTransactions[i][6] = trans.get("txid").toString();
+				strTransactions[i][3] = " ";
+	    	strTransactions[i][4] = trans.get("amount").toString();
+	    	strTransactions[i][5] = trans.get("time").toString();
+	    	strTransactions[i][6] = trans.getString("address", notListed + " (Z Address not listed by wallet!)");
+	    	strTransactions[i][7] = trans.get("txid").toString();
 
 	    }
 
@@ -299,17 +300,26 @@ public class BTCZClientCaller
 	public synchronized String[][] getWalletZReceivedTransactions()
 		throws WalletCallException, IOException, InterruptedException
 	{
-		List<String> zAddresses = this.getWalletZAddresses().get(0);
+
+		// Modified to get also the Viewing Key
+		List<List> zAdrrData = this.getWalletZAddresses();
+		List<String> zAddresses = zAdrrData.get(0);
+		List<Boolean> isVKsOnly = zAdrrData.get(1);
 
 		List<String[]> zReceivedTransactions = new ArrayList<String[]>();
 
+		int k = 0;
 		for (String zAddress : zAddresses)
 		{
+
+				boolean isVKonly = isVKsOnly.get(k);
+				k++;
+
 		    JsonArray jsonTransactions = executeCommandAndGetJsonArray(
 		    	"z_listreceivedbyaddress", wrapStringParameter(zAddress), "0");
 		    for (int i = 0; i < jsonTransactions.size(); i++)
 		    {
-		    	String[] currentTransaction = new String[7];
+		    	String[] currentTransaction = new String[8];
 		    	JsonObject trans = jsonTransactions.get(i).asObject();
 
 		    	String txID = trans.getString("txid", "ERROR!");
@@ -318,10 +328,11 @@ public class BTCZClientCaller
 		    	currentTransaction[0] = "\u2605Z (Private)";
 		    	currentTransaction[1] = "receive";
 		    	currentTransaction[2] = this.getWalletTransactionConfirmations(txID);
-		    	currentTransaction[3] = trans.get("amount").toString();
-		    	currentTransaction[4] = this.getWalletTransactionTime(txID); // TODO: minimize sub-calls
-		    	currentTransaction[5] = zAddress;
-		    	currentTransaction[6] = trans.get("txid").toString();
+					currentTransaction[3] = isVKonly ? ("vk") : ("");
+		    	currentTransaction[4] = trans.get("amount").toString();
+		    	currentTransaction[5] = this.getWalletTransactionTime(txID); // TODO: minimize sub-calls
+		    	currentTransaction[6] = zAddress;
+		    	currentTransaction[7] = trans.get("txid").toString();
 
 		    	zReceivedTransactions.add(currentTransaction);
 		    }

--- a/src/java/com/bitcoinz/btczui/BtczUI.java
+++ b/src/java/com/bitcoinz/btczui/BtczUI.java
@@ -116,7 +116,7 @@ public class BtczUI
     public BtczUI(StartupProgressDialog progressDialog)
         throws IOException, InterruptedException, WalletCallException
     {
-        super("BitcoinZ Wallet 2.0.7-u3");
+        super("BitcoinZ Wallet 2.0.8-rc1");
 
         if (progressDialog != null)
         {

--- a/src/java/com/bitcoinz/btczui/BtczUI.java
+++ b/src/java/com/bitcoinz/btczui/BtczUI.java
@@ -116,7 +116,7 @@ public class BtczUI
     public BtczUI(StartupProgressDialog progressDialog)
         throws IOException, InterruptedException, WalletCallException
     {
-        super("BitcoinZ Wallet 2.0.8-rc1");
+        super("BitcoinZ Wallet 2.0.8");
 
         if (progressDialog != null)
         {

--- a/src/java/com/bitcoinz/btczui/DashboardPanel.java
+++ b/src/java/com/bitcoinz/btczui/DashboardPanel.java
@@ -587,16 +587,17 @@ public class DashboardPanel
 	private JTable createTransactionsTable(String rowData[][])
 		throws WalletCallException, IOException, InterruptedException
 	{
-		String columnNames[] = { "Type", "Direction", "Confirmed?", "Amount", "Date", "Destination Address"};
+		String columnNames[] = { "Type", "Direction", "Confirmed?", " ", "Amount", "Date", "Destination Address"};
         JTable table = new TransactionTable(
         	rowData, columnNames, this.parentFrame, this.clientCaller, this.installationObserver);
         table.setAutoResizeMode(JTable.AUTO_RESIZE_SUBSEQUENT_COLUMNS);
         table.getColumnModel().getColumn(0).setPreferredWidth(190);
         table.getColumnModel().getColumn(1).setPreferredWidth(145);
         table.getColumnModel().getColumn(2).setPreferredWidth(170);
-        table.getColumnModel().getColumn(3).setPreferredWidth(210);
-        table.getColumnModel().getColumn(4).setPreferredWidth(405);
-        table.getColumnModel().getColumn(5).setPreferredWidth(800);
+				table.getColumnModel().getColumn(3).setPreferredWidth(80);
+        table.getColumnModel().getColumn(4).setPreferredWidth(210);
+        table.getColumnModel().getColumn(5).setPreferredWidth(405);
+        table.getColumnModel().getColumn(6).setPreferredWidth(800);
 
         return table;
 	}
@@ -628,15 +629,15 @@ public class DashboardPanel
 			public int compare(String[] o1, String[] o2)
 			{
 				Date d1 = new Date(0);
-				if (!o1[4].equals("N/A"))
+				if (!o1[5].equals("N/A"))
 				{
-					d1 = new Date(Long.valueOf(o1[4]).longValue() * 1000L);
+					d1 = new Date(Long.valueOf(o1[5]).longValue() * 1000L);
 				}
 
 				Date d2 = new Date(0);
-				if (!o2[4].equals("N/A"))
+				if (!o2[5].equals("N/A"))
 				{
-					d2 = new Date(Long.valueOf(o2[4]).longValue() * 1000L);
+					d2 = new Date(Long.valueOf(o2[5]).longValue() * 1000L);
 				}
 
 				if (d1.equals(d2))
@@ -684,23 +685,23 @@ public class DashboardPanel
 			};
 
 			// Date
-			if (!trans[4].equals("N/A"))
+			if (!trans[5].equals("N/A"))
 			{
-				trans[4] = new Date(Long.valueOf(trans[4]).longValue() * 1000L).toLocaleString();
+				trans[5] = new Date(Long.valueOf(trans[5]).longValue() * 1000L).toLocaleString();
 			}
 
 			// Amount
 			try
 			{
-				double amount = Double.valueOf(trans[3]);
+				double amount = Double.valueOf(trans[4]);
 				if (amount < 0d)
 				{
 					amount = -amount;
 				}
-				trans[3] = df.format(amount);
+				trans[4] = df.format(amount);
 			} catch (NumberFormatException nfe)
 			{
-				Log.error("Error occurred while formatting amount: " + trans[3] +
+				Log.error("Error occurred while formatting amount: " + trans[4] +
 						           " - " + nfe.getMessage() + "!");
 			}
 

--- a/src/java/com/bitcoinz/btczui/RawTXPanel.java
+++ b/src/java/com/bitcoinz/btczui/RawTXPanel.java
@@ -52,6 +52,7 @@ import java.math.RoundingMode;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.swing.BorderFactory;
@@ -666,7 +667,7 @@ public class RawTXPanel
 		throws WalletCallException, IOException, InterruptedException
 	{
 		// Z Addresses - they are OK
-		String[] zAddresses = clientCaller.getWalletZAddresses();
+		List<String>  zAddresses = clientCaller.getWalletZAddresses().get(0);
 
 		// T Addresses created inside wallet that may be empty
 		String[] tAddresses = this.clientCaller.getWalletAllPublicAddresses();
@@ -689,7 +690,7 @@ public class RawTXPanel
 		tAddressesCombined.addAll(tStoredAddressSet);
 		tAddressesCombined.addAll(tAddressSetWithUnspentOuts);
 
-		String[][] tempAddressBalances = new String[zAddresses.length + tAddressesCombined.size()][];
+		String[][] tempAddressBalances = new String[zAddresses.size() + tAddressesCombined.size()][];
 
 		int count = 0;
 

--- a/src/java/com/bitcoinz/btczui/SendCashPanel.java
+++ b/src/java/com/bitcoinz/btczui/SendCashPanel.java
@@ -51,6 +51,7 @@ import java.math.RoundingMode;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.swing.BorderFactory;
@@ -651,7 +652,7 @@ public class SendCashPanel
 		throws WalletCallException, IOException, InterruptedException
 	{
 		// Z Addresses - they are OK
-		String[] zAddresses = clientCaller.getWalletZAddresses();
+		List<String> zAddresses = clientCaller.getWalletZAddresses().get(0);
 
 		// T Addresses created inside wallet that may be empty
 		String[] tAddresses = this.clientCaller.getWalletAllPublicAddresses();
@@ -674,7 +675,7 @@ public class SendCashPanel
 		tAddressesCombined.addAll(tStoredAddressSet);
 		tAddressesCombined.addAll(tAddressSetWithUnspentOuts);
 
-		String[][] tempAddressBalances = new String[zAddresses.length + tAddressesCombined.size()][];
+		String[][] tempAddressBalances = new String[zAddresses.size() + tAddressesCombined.size()][];
 
 		int count = 0;
 

--- a/src/java/com/bitcoinz/btczui/SendCashPanel.java
+++ b/src/java/com/bitcoinz/btczui/SendCashPanel.java
@@ -621,6 +621,8 @@ public class SendCashPanel
 
 		lastAddressBalanceData = newAddressBalanceData;
 
+		// TODO: Find a way to remove the VK
+
 		comboBoxItems = new String[lastAddressBalanceData.length];
 		for (int i = 0; i < lastAddressBalanceData.length; i++)
 		{
@@ -651,8 +653,11 @@ public class SendCashPanel
 	private String[][] getAddressPositiveBalanceDataFromWallet()
 		throws WalletCallException, IOException, InterruptedException
 	{
-		// Z Addresses - they are OK
-		List<String> zAddresses = clientCaller.getWalletZAddresses().get(0);
+		// Z Addresses
+		// Modified to get also the Viewing Key
+		List<List> zAdrrData = clientCaller.getWalletZAddresses();
+		List<String> zAddresses = zAdrrData.get(0);
+		List<Boolean> isVKsOnly = zAdrrData.get(1);
 
 		// T Addresses created inside wallet that may be empty
 		String[] tAddresses = this.clientCaller.getWalletAllPublicAddresses();
@@ -686,19 +691,24 @@ public class SendCashPanel
 			{
 				tempAddressBalances[count++] = new String[]
 				{
-					balance, address
+					balance, address, ""
 				};
 			}
 		}
 
+		int k = 0;
 		for (String address : zAddresses)
 		{
 			String balance = this.clientCaller.getBalanceForAddress(address);
+
+			boolean isVKonly = isVKsOnly.get(k);
+			k++;
+
 			if (Double.valueOf(balance) > 0)
 			{
 				tempAddressBalances[count++] = new String[]
 				{
-					balance, address
+					balance, address, isVKonly ? ("vk") : ("")
 				};
 			}
 		}

--- a/src/java/com/bitcoinz/btczui/StartupProgressDialog.java
+++ b/src/java/com/bitcoinz/btczui/StartupProgressDialog.java
@@ -74,7 +74,7 @@ public class StartupProgressDialog extends JFrame {
         contentPane.add(imageLabel, BorderLayout.NORTH);
     		JLabel bitcoinzWalletLabel = new JLabel(
     			"<html><b><span style=\"font-weight:bold;font-size:2.2em\">" +
-    		  "BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.8-rc1</html>");
+    		  "BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.8</html>");
 
     		bitcoinzWalletLabel.setBorder(BorderFactory.createEmptyBorder(16, 16, 16, 16));
     		// todo - place in a panel with flow center

--- a/src/java/com/bitcoinz/btczui/StartupProgressDialog.java
+++ b/src/java/com/bitcoinz/btczui/StartupProgressDialog.java
@@ -74,7 +74,7 @@ public class StartupProgressDialog extends JFrame {
         contentPane.add(imageLabel, BorderLayout.NORTH);
     		JLabel bitcoinzWalletLabel = new JLabel(
     			"<html><b><span style=\"font-weight:bold;font-size:2.2em\">" +
-    		  "BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.7-u3</html>");
+    		  "BitcoinZ Wallet UI</span></b><br>&nbsp;Version 2.0.8-rc1</html>");
 
     		bitcoinzWalletLabel.setBorder(BorderFactory.createEmptyBorder(16, 16, 16, 16));
     		// todo - place in a panel with flow center

--- a/src/java/com/bitcoinz/btczui/TransactionTable.java
+++ b/src/java/com/bitcoinz/btczui/TransactionTable.java
@@ -87,7 +87,7 @@ public class TransactionTable
 				{
 					try
 					{
-						String txID = TransactionTable.this.getModel().getValueAt(lastRow, 6).toString();
+						String txID = TransactionTable.this.getModel().getValueAt(lastRow, 7).toString();
 						txID = txID.replaceAll("\"", ""); // In case it has quotes
 
 						Log.info("Transaction ID for detail dialog is: " + txID);
@@ -160,10 +160,10 @@ public class TransactionTable
 					Cursor oldCursor = parent.getCursor();
 					try
 					{
-						String txID = TransactionTable.this.getModel().getValueAt(lastRow, 6).toString();
+						String txID = TransactionTable.this.getModel().getValueAt(lastRow, 7).toString();
 						txID = txID.replaceAll("\"", ""); // In case it has quotes
 
-						String acc = TransactionTable.this.getModel().getValueAt(lastRow, 5).toString();
+						String acc = TransactionTable.this.getModel().getValueAt(lastRow, 6).toString();
 						acc = acc.replaceAll("\"", ""); // In case it has quotes
 
 						boolean isZAddress = Util.isZAddress(acc);

--- a/src/java/com/bitcoinz/btczui/msg/CreateGroupDialog.java
+++ b/src/java/com/bitcoinz/btczui/msg/CreateGroupDialog.java
@@ -35,6 +35,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.swing.BorderFactory;
@@ -259,20 +260,20 @@ public class CreateGroupDialog
 		throws IOException, InterruptedException, WalletCallException
 	{
 		String key = Util.convertGroupPhraseToZPrivateKey(keyPhrase);
+		List<String> zAddresses = caller.getWalletZAddresses().get(0);
 
 		// There is no way (it seems) to find out what Z address was added - we need to
 		// analyze which one it is.
 		// TODO: This relies that noone is importing keys at the same time!
 		Set<String> addressesBeforeAddition = new HashSet<String>();
-		for (String address: this.caller.getWalletZAddresses())
+		for (String address: zAddresses)
 		{
 			addressesBeforeAddition.add(address);
 		}
 
 		CreateGroupDialog.this.caller.importPrivateKey(key);
-
 		Set<String> addressesAfterAddition = new HashSet<String>();
-		for (String address: this.caller.getWalletZAddresses())
+		for (String address : zAddresses)
 		{
 			addressesAfterAddition.add(address);
 		}
@@ -386,8 +387,9 @@ public class CreateGroupDialog
 		throws InterruptedException, WalletCallException, IOException
 	{
 		String address = null;
+		List<String>  zAddresses = caller.getWalletZAddresses().get(0);
 
-		for (String zAddr : this.caller.getWalletZAddresses())
+		for (String zAddr : zAddresses)
 		{
 			String privKey = this.caller.getZPrivateKey(zAddr);
 			if (privKey.equals(key))

--- a/src/java/com/bitcoinz/btczui/msg/MessagingPanel.java
+++ b/src/java/com/bitcoinz/btczui/msg/MessagingPanel.java
@@ -1527,7 +1527,7 @@ public class MessagingPanel
 			if ((ownIdentity != null) && (!this.identityZAddressValidityChecked))
 			{
 				String ownZAddress = ownIdentity.getSendreceiveaddress();
-				String[] walletZaddresses = this.clientCaller.getWalletZAddresses();
+				List<String> walletZaddresses = this.clientCaller.getWalletZAddresses().get(0);
 
 				boolean bFound = false;
 				for (String address : walletZaddresses)

--- a/src/resources/ubuntu-package/BitcoinZWallet.desktop
+++ b/src/resources/ubuntu-package/BitcoinZWallet.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=2.0.8-rc1
+Version=2.0.8
 Name=BitcoinZ Wallet
 Comment=BitcoinZ Desktop GUI Wallet (full node)
 GenericName=BitcoinZ Wallet

--- a/src/resources/ubuntu-package/BitcoinZWallet.desktop
+++ b/src/resources/ubuntu-package/BitcoinZWallet.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=2.0.7-u3
+Version=2.0.8-rc1
 Name=BitcoinZ Wallet
 Comment=BitcoinZ Desktop GUI Wallet (full node)
 GenericName=BitcoinZ Wallet

--- a/src/resources/ubuntu-package/control
+++ b/src/resources/ubuntu-package/control
@@ -1,5 +1,5 @@
 Package: bitcoinz-wallet
-Version: 2.0.8-rc1
+Version: 2.0.8
 Section: misc
 Priority: low
 Architecture: all

--- a/src/resources/ubuntu-package/control
+++ b/src/resources/ubuntu-package/control
@@ -1,5 +1,5 @@
 Package: bitcoinz-wallet
-Version: 2.0.7-u3
+Version: 2.0.8-rc1
 Section: misc
 Priority: low
 Architecture: all


### PR DESCRIPTION
This update add the capability to import Viewing key: Menu -> Wallet -> Import one private key...
The import do not re-scan. So only the txs from the import time will be show in the UI.
A new "tag was added "VK" that means that its an Viewing Key only.
This version also need the 2.0.8-rc1 node.

For more info look the node PR: https://github.com/btcz/bitcoinz/pull/69
